### PR TITLE
Output brief, more concise information only

### DIFF
--- a/src/clap-info/main.cpp
+++ b/src/clap-info/main.cpp
@@ -115,11 +115,23 @@ int main(int argc, char **argv)
     bool searchPath{false};
     app.add_flag("--search-path", searchPath, "Show the CLAP plugin search paths then exit");
 
+    bool brief{false};
+    app.add_flag("--brief", brief, "Output brief infomation only");
 
     CLI11_PARSE(app, argc, argv);
 
     CLAPInfoJsonRoot doc;
     doc.outFile = outFile;
+
+    // If brief param is set, override other params to output concise information only
+    if (brief)
+    {
+        annExt = false;
+        audioPorts = false;
+        notePorts = false;
+        paramShow = false;
+        otherExt = false;
+    }
 
     if (searchPath)
     {


### PR DESCRIPTION
```
$ ./build/clap-info "./plugins/Surge XT.clap" --brief
{
   "clap-version" : "1.0.2",
   "file" : "./plugins/Surge XT.clap",
   "plugin_count" : 1,
   "plugins" : [
      {
         "descriptor" : {
            "description" : "Surge XT",
            "features" : [ "instrument", "hybrid", "free and open source" ],
            "id" : "org.surge-synth-team.surge-xt",
            "name" : "Surge XT",
            "version" : "1.1.0"
         },
         "extensions" : null,
         "plugin-index" : 0
      }
   ]
}
```