### PR TITLE
Linux DLOpen failure reports dlerror

### DIFF
--- a/src/clap-scanner/resolve_entrypoint.cpp
+++ b/src/clap-scanner/resolve_entrypoint.cpp
@@ -70,6 +70,11 @@ const clap_plugin_entry_t *entryFromCLAPPath(const std::filesystem::path &p)
     int *iptr;
 
     handle = dlopen(p.u8string().c_str(), RTLD_LOCAL | RTLD_LAZY);
+    if (!handle)
+    {
+        std::cerr << "dlopen failed on Linux: " << dlerror() << std::endl;
+	return nullptr;
+    }
 
     iptr = (int *)dlsym(handle, "clap_entry");
 


### PR DESCRIPTION
clap-info when dlopen fails will report a dlerror