### PR TITLE
Make plug initialisation step compliant with the spec

### DIFF
--- a/src/clap-info/main.cpp
+++ b/src/clap-info/main.cpp
@@ -358,7 +358,12 @@ int main(int argc, char **argv)
 	    return 5;
 	}
 
-        inst->init(inst);
+        bool result = inst->init(inst);
+	if (!result) {
+	    std::cerr << "Unable to init plugin" << std::endl;
+	    doc.active = false;
+            return 6;
+	}
         inst->activate(inst, 48000, 32, 4096);
 
         Json::Value extensions;


### PR DESCRIPTION
According to the official header [plugin.h](https://github.com/free-audio/clap/blob/main/include/clap/plugin.h)

```c
// If init returns false, the host must destroy the plugin instance.
   // If init returns true, then the plugin is initialized and in the deactivated state.
```

Trying to activate the plugin when it cannot be initialised can result in an instant crash.