### PR TITLE
Sync CLI version with CMake project version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_policy(SET CMP0091 NEW)
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15 CACHE STRING "Minimum macOS version")
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
-project(clap-info VERSION 1.0.0 LANGUAGES C CXX)
+project(clap-info VERSION 1.2.2 LANGUAGES C CXX)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_CXX_STANDARD 17)
 
@@ -95,5 +95,6 @@ else()
     target_compile_definitions(clap-scanner PUBLIC WIN=1)
 endif()
 
+target_compile_definitions(${PROJECT_NAME} PRIVATE CLAP_INFO_VERSION="${PROJECT_VERSION}")
 target_include_directories(${PROJECT_NAME} PRIVATE src)
 target_link_libraries(${PROJECT_NAME} PRIVATE CLI11 jsoncpp clap-scanner)

--- a/src/clap-info/main.cpp
+++ b/src/clap-info/main.cpp
@@ -59,7 +59,7 @@ int main(int argc, char **argv)
 {
     CLI::App app("clap-info: CLAP command line validation tool");
 
-    app.set_version_flag("--version", "0.9.0");
+    app.set_version_flag("--version", CLAP_INFO_VERSION);
     std::string clap;
     app.add_option("-f,--file,file", clap, "CLAP plugin file location");
 


### PR DESCRIPTION
`clap-info --version` was still reporting "0.9.0", while the current release version is "1.2.2". The CMake project version was also still set to "1.0.0".
This updates the CMake project version to "1.2.2" and uses `PROJECT_VERSION` for the CLI version output. Going forward, updating PROJECT_VERSION for each release will keep --version in sync.